### PR TITLE
Fix for Endless Round Bug

### DIFF
--- a/lua/terrortown/entities/roles/duelist/shared.lua
+++ b/lua/terrortown/entities/roles/duelist/shared.lua
@@ -161,7 +161,7 @@ if SERVER then
 
     for _, ply in ipairs(player.GetAll()) do
       if not IsValid(ply) or not ply:Alive() then continue end
-			if SpecDM and (ply.IsGhost and ply:IsGhost() or (vics.IsGhost and vics:IsGhost())) then continue end
+			if SpecDM and (ply.IsGhost and ply:IsGhost()) then continue end
 
       if ply:GetSubRole() == ROLE_DUELIST then
         table.insert(alives, "duelist-" .. ply:GetName())


### PR DESCRIPTION
Fixes Issue #1 

I am unsure what the reference to an undefined vics entity was intended to do, but removing it didn't break the role and fixed the bug where the first round on a map wouldn't end.